### PR TITLE
pyramids v0.23.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pyramids--netcdf--lazy-green.svg)](https://anaconda.org/conda-forge/pyramids-netcdf-lazy) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyramids-netcdf-lazy.svg)](https://anaconda.org/conda-forge/pyramids-netcdf-lazy) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyramids-netcdf-lazy.svg)](https://anaconda.org/conda-forge/pyramids-netcdf-lazy) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyramids-netcdf-lazy.svg)](https://anaconda.org/conda-forge/pyramids-netcdf-lazy) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pyramids--parquet-green.svg)](https://anaconda.org/conda-forge/pyramids-parquet) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyramids-parquet.svg)](https://anaconda.org/conda-forge/pyramids-parquet) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyramids-parquet.svg)](https://anaconda.org/conda-forge/pyramids-parquet) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyramids-parquet.svg)](https://anaconda.org/conda-forge/pyramids-parquet) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pyramids--parquet--lazy-green.svg)](https://anaconda.org/conda-forge/pyramids-parquet-lazy) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyramids-parquet-lazy.svg)](https://anaconda.org/conda-forge/pyramids-parquet-lazy) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyramids-parquet-lazy.svg)](https://anaconda.org/conda-forge/pyramids-parquet-lazy) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyramids-parquet-lazy.svg)](https://anaconda.org/conda-forge/pyramids-parquet-lazy) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pyramids--stac-green.svg)](https://anaconda.org/conda-forge/pyramids-stac) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyramids-stac.svg)](https://anaconda.org/conda-forge/pyramids-stac) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyramids-stac.svg)](https://anaconda.org/conda-forge/pyramids-stac) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyramids-stac.svg)](https://anaconda.org/conda-forge/pyramids-stac) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pyramids--viz-green.svg)](https://anaconda.org/conda-forge/pyramids-viz) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyramids-viz.svg)](https://anaconda.org/conda-forge/pyramids-viz) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyramids-viz.svg)](https://anaconda.org/conda-forge/pyramids-viz) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyramids-viz.svg)](https://anaconda.org/conda-forge/pyramids-viz) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pyramids--xarray-green.svg)](https://anaconda.org/conda-forge/pyramids-xarray) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyramids-xarray.svg)](https://anaconda.org/conda-forge/pyramids-xarray) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyramids-xarray.svg)](https://anaconda.org/conda-forge/pyramids-xarray) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyramids-xarray.svg)](https://anaconda.org/conda-forge/pyramids-xarray) |
 
@@ -51,16 +52,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `pyramids, pyramids-lazy, pyramids-netcdf-lazy, pyramids-parquet, pyramids-parquet-lazy, pyramids-viz, pyramids-xarray` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `pyramids, pyramids-lazy, pyramids-netcdf-lazy, pyramids-parquet, pyramids-parquet-lazy, pyramids-stac, pyramids-viz, pyramids-xarray` can be installed with `conda`:
 
 ```
-conda install pyramids pyramids-lazy pyramids-netcdf-lazy pyramids-parquet pyramids-parquet-lazy pyramids-viz pyramids-xarray
+conda install pyramids pyramids-lazy pyramids-netcdf-lazy pyramids-parquet pyramids-parquet-lazy pyramids-stac pyramids-viz pyramids-xarray
 ```
 
 or with `mamba`:
 
 ```
-mamba install pyramids pyramids-lazy pyramids-netcdf-lazy pyramids-parquet pyramids-parquet-lazy pyramids-viz pyramids-xarray
+mamba install pyramids pyramids-lazy pyramids-netcdf-lazy pyramids-parquet pyramids-parquet-lazy pyramids-stac pyramids-viz pyramids-xarray
 ```
 
 It is possible to list all of the versions of `pyramids` available on your platform with `conda`:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set python_min = "3.11" %}
 {% set name = "pyramids" %}
-{% set version = "0.21.0" %}
+{% set version = "0.23.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/serapeum-org/pyramids/archive/{{ version }}.tar.gz
-  sha256: a4c8bacdcdb25a6af01c6543dc469625b5ef63b6fd44a2a9c91199160c645366
+  sha256: 4d2086dece3f7995542c28c96302c442b0395e9e328677c1356ebc06b6dd3296
 
 build:
   number: 0
@@ -61,7 +61,9 @@ requirements:
     - pyarrow >=10.0.0
     # parquet-lazy
     - dask-geopandas >=0.5.0
-    # stac — conda-forge equivalent of the PyPI `stac` extra.
+    # stac — conda-forge equivalent of the PyPI `stac` extra. The PyPI extra also
+    # pins stac-asset>=0.4.7, which is not yet packaged on conda-forge; add it here
+    # once it lands on the channel.
     - pystac-client >=0.8.0
 
 test:
@@ -156,7 +158,8 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage(name, exact=True) }}
-        # conda-forge equivalent of the PyPI `stac` extra (pystac-client).
+        # conda-forge equivalent of the PyPI `stac` extra. stac-asset>=0.4.7 (also
+        # part of the PyPI extra) is not yet on conda-forge; add it once available.
         - pystac-client >=0.8.0
     test:
       imports:


### PR DESCRIPTION
Updates the feedstock to pyramids 0.23.0.

## Changes

- Bump `version` to `0.23.0` and update `sha256` (verified against the
  `0.23.0.tar.gz` GitHub archive).
- Carries the re-rendered README and the `pyramids-stac` output introduced for
  0.21.0 (this PR brings `main` straight from 0.21.0 to 0.23.0).

## Note on the `stac` extra

pyramids 0.23.0 extends the PyPI `stac` extra to `pystac-client>=0.8.0` +
`stac-asset>=0.4.7`. `stac-asset` is **not yet packaged on conda-forge**, so it is
intentionally omitted from the `pyramids-stac` output for now; the recipe carries a
comment to add it once it lands on the channel. `pyramids-stac` therefore currently
ships `pystac-client` only.

## Checklist

- [x] Used a personal fork/branch of the feedstock to propose changes
- [x] Bumped the build number to 0 (new version)
- [x] Re-rendered with the latest conda-smithy
- [x] Ensured the license file is being packaged
