### PR TITLE
pyramids v0.24.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set python_min = "3.11" %}
 {% set name = "pyramids" %}
-{% set version = "0.24.0" %}
+{% set version = "0.24.1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/serapeum-org/pyramids/archive/{{ version }}.tar.gz
-  sha256: 22431b484d3a0a8bb612508cf648486eb8704f60809a18966ea83371f13ec015
+  sha256: babdee3a285794e4f080cb09cf559ca37b2bf29ebb3caa490ac187052097dca8
 
 build:
   number: 0


### PR DESCRIPTION
Updates the feedstock to pyramids 0.24.1.

## Changes

- Bump `version` to `0.24.1` and update `sha256` (verified against the `0.24.1.tar.gz` GitHub archive).

## Notes

0.24.1 is a version-only change relative to 0.24.0 — `pyproject.toml` differs solely in the version string,
with no dependency, extra, output, or entry-point changes. The recipe therefore carries over the 0.24.0 state
unchanged (core deps incl. `cftime`, the `pyramids` CLI smoke-test, and all metapackage outputs).

The `stac` extra's `stac-asset>=0.4.7` remains intentionally omitted, as `stac-asset` is not yet packaged on
conda-forge (documented in-recipe).
