### PR TITLE
pyramids v0.25.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set python_min = "3.11" %}
 {% set name = "pyramids" %}
-{% set version = "0.25.0" %}
+{% set version = "0.25.1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/serapeum-org/pyramids/archive/{{ version }}.tar.gz
-  sha256: df152f78b4674c4a64fc9892c1a1cdf9e32dfef4c509fdc87730ccb762e1913d
+  sha256: cf711ad5973a9337a72a0d96809472e1a0e86bef20c7d3fb80011cf5716536e7
 
 build:
   number: 0


### PR DESCRIPTION
Bumps `pyramids` to 0.25.1.

Patch release — bug fix only (vendored-GDAL `/vsicurl` CA bundle, no public API or dependency changes from
0.25.0). Pure version + sha256 update; build number reset to 0; recipe requirements unchanged.

Checklist:
- [x] Used a personal/maintainer branch on the feedstock, not a fork branch on `main`.
- [x] Bumped the version string and reset/kept the build number at 0.
- [x] Updated the sha256 (GitHub archive tarball for tag `0.25.1`).
- [x] Dependencies reviewed against upstream `0.25.1` — unchanged vs `0.25.0`.
