### PR TITLE
pyramids v0.26.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set python_min = "3.11" %}
 {% set name = "pyramids" %}
-{% set version = "0.25.1" %}
+{% set version = "0.26.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/serapeum-org/pyramids/archive/{{ version }}.tar.gz
-  sha256: cf711ad5973a9337a72a0d96809472e1a0e86bef20c7d3fb80011cf5716536e7
+  sha256: 11073f80841ba7f214bd8b0a57dfb10012de60fa4cd29443b4ed3e60e67b962a
 
 build:
   number: 0


### PR DESCRIPTION
Updates the recipe to pyramids 0.26.0.

- `version` bumped 0.25.1 -> 0.26.0
- `sha256` updated for the new source tarball (`archive/0.26.0.tar.gz`)
- build number is 0 (new version)

Checklist:
- [x] Bumped to the new version and reset the build number to 0
- [x] Updated the source sha256
- [x] No recipe structure or CI configuration changes (re-render not required)
