### PR TITLE
Drop removed outputs from README (post-0.33.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,9 @@ Current release info
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pyramids-green.svg)](https://anaconda.org/conda-forge/pyramids) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyramids.svg)](https://anaconda.org/conda-forge/pyramids) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyramids.svg)](https://anaconda.org/conda-forge/pyramids) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyramids.svg)](https://anaconda.org/conda-forge/pyramids) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pyramids--lazy-green.svg)](https://anaconda.org/conda-forge/pyramids-lazy) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyramids-lazy.svg)](https://anaconda.org/conda-forge/pyramids-lazy) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyramids-lazy.svg)](https://anaconda.org/conda-forge/pyramids-lazy) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyramids-lazy.svg)](https://anaconda.org/conda-forge/pyramids-lazy) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-pyramids--netcdf--lazy-green.svg)](https://anaconda.org/conda-forge/pyramids-netcdf-lazy) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyramids-netcdf-lazy.svg)](https://anaconda.org/conda-forge/pyramids-netcdf-lazy) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyramids-netcdf-lazy.svg)](https://anaconda.org/conda-forge/pyramids-netcdf-lazy) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyramids-netcdf-lazy.svg)](https://anaconda.org/conda-forge/pyramids-netcdf-lazy) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pyramids--parquet-green.svg)](https://anaconda.org/conda-forge/pyramids-parquet) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyramids-parquet.svg)](https://anaconda.org/conda-forge/pyramids-parquet) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyramids-parquet.svg)](https://anaconda.org/conda-forge/pyramids-parquet) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyramids-parquet.svg)](https://anaconda.org/conda-forge/pyramids-parquet) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-pyramids--parquet--lazy-green.svg)](https://anaconda.org/conda-forge/pyramids-parquet-lazy) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyramids-parquet-lazy.svg)](https://anaconda.org/conda-forge/pyramids-parquet-lazy) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyramids-parquet-lazy.svg)](https://anaconda.org/conda-forge/pyramids-parquet-lazy) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyramids-parquet-lazy.svg)](https://anaconda.org/conda-forge/pyramids-parquet-lazy) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pyramids--stac-green.svg)](https://anaconda.org/conda-forge/pyramids-stac) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyramids-stac.svg)](https://anaconda.org/conda-forge/pyramids-stac) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyramids-stac.svg)](https://anaconda.org/conda-forge/pyramids-stac) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyramids-stac.svg)](https://anaconda.org/conda-forge/pyramids-stac) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pyramids--viz-green.svg)](https://anaconda.org/conda-forge/pyramids-viz) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyramids-viz.svg)](https://anaconda.org/conda-forge/pyramids-viz) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyramids-viz.svg)](https://anaconda.org/conda-forge/pyramids-viz) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyramids-viz.svg)](https://anaconda.org/conda-forge/pyramids-viz) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-pyramids--xarray-green.svg)](https://anaconda.org/conda-forge/pyramids-xarray) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyramids-xarray.svg)](https://anaconda.org/conda-forge/pyramids-xarray) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyramids-xarray.svg)](https://anaconda.org/conda-forge/pyramids-xarray) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyramids-xarray.svg)](https://anaconda.org/conda-forge/pyramids-xarray) |
 
 Installing pyramids
 ===================
@@ -54,16 +51,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `pyramids, pyramids-lazy, pyramids-netcdf-lazy, pyramids-parquet, pyramids-parquet-lazy, pyramids-stac, pyramids-viz, pyramids-xarray` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `pyramids, pyramids-lazy, pyramids-parquet, pyramids-stac, pyramids-viz` can be installed with `conda`:
 
 ```
-conda install pyramids pyramids-lazy pyramids-netcdf-lazy pyramids-parquet pyramids-parquet-lazy pyramids-stac pyramids-viz pyramids-xarray
+conda install pyramids pyramids-lazy pyramids-parquet pyramids-stac pyramids-viz
 ```
 
 or with `mamba`:
 
 ```
-mamba install pyramids pyramids-lazy pyramids-netcdf-lazy pyramids-parquet pyramids-parquet-lazy pyramids-stac pyramids-viz pyramids-xarray
+mamba install pyramids pyramids-lazy pyramids-parquet pyramids-stac pyramids-viz
 ```
 
 It is possible to list all of the versions of `pyramids` available on your platform with `conda`:


### PR DESCRIPTION
Removes the conda outputs that were dropped in pyramids 0.33.0 from the README.

The 0.33.0 recipe (merged in #41) reorganized the extras: `netcdf-lazy`, `parquet-lazy`,
and `xarray` are no longer separate output packages (kerchunk/h5py folded into `pyramids-lazy`,
dask-geopandas into `pyramids-parquet`, xarray is a peer interop dep). The auto-generated README
still advertised the removed packages in the badge table and the conda/mamba install commands.

This updates the README to list only the current outputs: `pyramids`, `pyramids-lazy`,
`pyramids-parquet`, `pyramids-stac`, `pyramids-viz`.
